### PR TITLE
lowercase plural labels

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@ get '/star.svg' do
       # everything is ok.
       content_type 'image/svg+xml'
       return create_button({
-        :button_text => 'Star',
+        :button_text => 'stars',
         :count_url   => "https://github.com/#{user}/#{repo}/stargazers",
         :count       => star_count,
         :button_url  => "https://github.com/#{user}/#{repo}"
@@ -47,7 +47,7 @@ get '/fork.svg' do
       # everything is ok.
       content_type 'image/svg+xml'
       return create_button({
-        :button_text => 'Fork',
+        :button_text => 'forks',
         :count_url   => "https://github.com/#{user}/#{repo}/network",
         :count       => fork_count,
         :button_url  => "https://github.com/#{user}/#{repo}/fork"


### PR DESCRIPTION
I think lowercase plural is a well accepted standard for these kind of buttons, see [here](https://github.com/chocolatey/chocolatey#chocolatey-nuget-like-apt-get-but-for-windows-----) for example.
