### PR TITLE
Better dimensions and border-radius

### DIFF
--- a/btn.haml
+++ b/btn.haml
@@ -31,12 +31,12 @@
               'stop-opacity' => '.1'}
         %stop{'offset' => '1',
               'stop-opacity' => '.5'}
-  %rect{'rx' => '4',
+  %rect{'rx' => '3',
         'width' => '80',
         'height' => '20',
         'fill' => '#555'}
 
-  %rect{'rx' => '4',
+  %rect{'rx' => '3',
         'x' => '37',
         'width' => '43',
         'height' => '20',
@@ -45,7 +45,7 @@
   %path{'fill' => "##{opts[:bg_color]}",
         'd' => 'M37 0h4v20h-4z'}
 
-  %rect{'rx'     => '4',
+  %rect{'rx'     => '3',
         'width'  => '80',
         'height' => '20',
         'fill'   => 'url(#a)'}


### PR DESCRIPTION
This should match the badges to shields.io ones.

Before:
![before](https://cloud.githubusercontent.com/assets/115237/5127965/10d5604e-70d8-11e4-96c6-474a9f3f3971.png)
After:
![after](https://cloud.githubusercontent.com/assets/115237/5127966/10fbd940-70d8-11e4-847e-1cf58f7e0dd1.png)
