### PR TITLE
feat: add flat-square style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ GET http://githubbadges.com
    Options:
     - `default` :  The default 'bubble' style
     - `flat` :  A flat style
+    - `flat-square` :  A flat style with no border-radius
 ```
 
 ### Example request

--- a/btn.haml
+++ b/btn.haml
@@ -21,6 +21,12 @@
               'stop-opacity' => '.1'}
         %stop{'offset' => 1,
               'stop-opacity' => '.1'}
+      - when 'flat-square'
+        %stop{'offset' => 0,
+              'stop-color' => "##{opts[:color]}",
+              'stop-opacity' => '.1'}
+        %stop{'offset' => 1,
+              'stop-opacity' => '.1'}
       - else
         -# Match default styling.
         %stop{'offset' => '0',
@@ -31,24 +37,41 @@
               'stop-opacity' => '.1'}
         %stop{'offset' => '1',
               'stop-opacity' => '.5'}
-  %rect{'rx' => '3',
-        'width' => '80',
-        'height' => '20',
-        'fill' => '#555'}
-
-  %rect{'rx' => '3',
-        'x' => '37',
-        'width' => '43',
-        'height' => '20',
-        'fill' => "##{opts[:bg_color]}"}
+  - case opts[:style]
+    - when 'flat-square'
+      %rect{'width' => '80',
+            'height' => '20',
+            'fill' => '#555'}
+    - else
+      %rect{'rx' => '3',
+            'width' => '80',
+            'height' => '20',
+            'fill' => '#555'}
+  - case opts[:style]
+    - when 'flat-square'
+      %rect{'x' => '37',
+            'width' => '43',
+            'height' => '20',
+            'fill' => "##{opts[:bg_color]}"}
+    - else
+      %rect{'rx' => '3',
+            'x' => '37',
+            'width' => '43',
+            'height' => '20',
+            'fill' => "##{opts[:bg_color]}"}
 
   %path{'fill' => "##{opts[:bg_color]}",
         'd' => 'M37 0h4v20h-4z'}
-
-  %rect{'rx'     => '3',
-        'width'  => '80',
-        'height' => '20',
-        'fill'   => 'url(#a)'}
+  - case opts[:style]
+    - when 'flat-square'
+      %rect{'width'  => '80',
+            'height' => '20',
+            'fill'   => 'url(#a)'}
+    - else
+      %rect{'rx'     => '3',
+            'width'  => '80',
+            'height' => '20',
+            'fill'   => 'url(#a)'}
 
   %g{'fill' => "##{opts[:color]}",
      'text-anchor' => 'middle',

--- a/views/index.haml
+++ b/views/index.haml
@@ -72,6 +72,9 @@
                 Default
               %option{:value => 'flat'}
                 Flat
+              %option{:value => 'flat-square'}
+                FlatSquare
+
 
           %button.btn.btn-success{:id => 'btn-generate'}
             Generate!


### PR DESCRIPTION
@ddavison 

I've added a `flat-square` style to match what https://shields.io/ has.

![Screen Shot 2019-12-28 at 19 26 05](https://user-images.githubusercontent.com/6936373/71542286-ff6f8f80-29a7-11ea-9c4e-c8a5c004d8fd.png)
![Screen Shot 2019-12-28 at 19 26 28](https://user-images.githubusercontent.com/6936373/71542287-ff6f8f80-29a7-11ea-95e6-421cd8939cf4.png)

It's my first time writing in haml, so if theres a more optimized way of doing case matching, please let me know.
